### PR TITLE
Issue 27 Page 2 update

### DIFF
--- a/src/badge/accomplishment/_accomplishment-badges.ts
+++ b/src/badge/accomplishment/_accomplishment-badges.ts
@@ -186,6 +186,7 @@ import {TheGreaterGood} from "./the-greater-good";
 import {WentOffScript} from "./went-off-script";
 import {UncivilWarrior} from "./uncivil-warrior";
 import {PowerLiberator} from "../accolade/power-liberator";
+import {Complicated} from "./complicated";
 
 export const AccomplishmentBadges: IBadgeData[] = [
 
@@ -194,10 +195,10 @@ export const AccomplishmentBadges: IBadgeData[] = [
     PirateHunter,
     Leviathan,
     CrystalKeeper,
-    PlagueCarrier,
-    MaskMaker,
     StoneCold,
     BoneCollector,
+    PlagueCarrier,
+    MaskMaker,
     PenitentOfVice,
     Seaweed,
     Strikebreaker,
@@ -314,6 +315,7 @@ export const AccomplishmentBadges: IBadgeData[] = [
     DarkHeart,
     BlackenedSoul,
     FaceOfEvil,
+    Complicated,
     HydraStomper,
     GerminatorTerminator,
     SpinDoctor,

--- a/src/badge/accomplishment/complicated.ts
+++ b/src/badge/accomplishment/complicated.ts
@@ -1,0 +1,21 @@
+import {ALIGNMENT_HERO, BadgeType, IBadgeData} from "coh-content-db";
+
+export const Negotiator: IBadgeData = {
+    type: BadgeType.ACCOMPLISHMENT,
+    key: "complicated",
+    setTitleId: 2459,
+    names: [
+        {value: "Complicated"}
+    ],
+    alignment: ALIGNMENT_HERO,
+    badgeText: [
+        {value: "Sometimes, the line between good and evil isn't as simple as it seems."}
+    ],
+    acquisition: "Complete the Defeat Frostfire mission from Flux",
+    links: [
+        {title: "Negotiator Badge", href: "https://paragonwiki.com/wiki/Complicated_Badge"}
+    ],
+    icons: [
+        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/complicated.png"}
+    ],
+};


### PR DESCRIPTION
Add Complicated badge. Changed icons and order for Stone Cold, Bone Collector, Plague Carrier, Mask Maker badges.

(Todo: Changed icons for hero accomplishment badges. Negotiator, Spelunker, etc.)