### PR TITLE
issue 27 page 2 update

### DIFF
--- a/src/badge/accomplishment/stone-cold.ts
+++ b/src/badge/accomplishment/stone-cold.ts
@@ -16,6 +16,6 @@ export const StoneCold: IBadgeData = {
         {title: "Stone Cold Badge", href: "https://paragonwiki.com/wiki/Stone_Cold_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-2.png"}
+        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-1.png"}
     ],
 };


### PR DESCRIPTION
Add Complicated badge. Changed icons and order for Stone Cold, Bone Collector, Plague Carrier, Mask Maker badges.

(Todo: Changed icons for hero accomplishment badges. Negotiator, Spelunker, etc.)