### PR TITLE
Issue 27 page 2 changed Mask Maker icon

### DIFF
--- a/src/badge/accomplishment/mask-maker.ts
+++ b/src/badge/accomplishment/mask-maker.ts
@@ -16,6 +16,6 @@ export const MaskMaker: IBadgeData = {
         {title: "Mask Maker Badge", href: "https://paragonwiki.com/wiki/Mask_Maker_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-1.png"}
+        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-2.png"}
     ],
 };


### PR DESCRIPTION
Add Complicated badge. Changed icons and order for Stone Cold, Bone Collector, Plague Carrier, Mask Maker badges.

(Todo: Changed icons for hero accomplishment badges. Negotiator, Spelunker, etc.)