### PR TITLE
issue 27 page 2 changed plague carrier icon

### DIFF
--- a/src/badge/accomplishment/plague-carrier.ts
+++ b/src/badge/accomplishment/plague-carrier.ts
@@ -16,6 +16,6 @@ export const PlagueCarrier: IBadgeData = {
         {title: "Plague Carrier Badge", href: "https://paragonwiki.com/wiki/Plague_Carrier_Badge"}
     ],
     icons: [
-        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-1.png"}
+        {value: "https://n15g.github.io/coh-content-db-homecoming/images/badges/accomplishment/stature-2.png"}
     ],
 };


### PR DESCRIPTION
Add Complicated badge. Changed icons and order for Stone Cold, Bone Collector, Plague Carrier, Mask Maker badges.

(Todo: Changed icons for hero accomplishment badges. Negotiator, Spelunker, etc.)